### PR TITLE
Use ISO_8859_1 encoding for reading strings from native lib

### DIFF
--- a/app/src/main/java/net/sigmabeta/chipbox/util/ByteArrayExtensions.kt
+++ b/app/src/main/java/net/sigmabeta/chipbox/util/ByteArrayExtensions.kt
@@ -1,5 +1,5 @@
 package net.sigmabeta.chipbox.util
 
 fun ByteArray.convert(): String {
-    return toString(charset("UTF-8"))
+    return toString(Charsets.ISO_8859_1)
 }


### PR DESCRIPTION
Fixes artist and track names with accented vowels and such rendering incorrectly.